### PR TITLE
feat: Implement Employee List page

### DIFF
--- a/frontend/src/lib/components/Sidebar.svelte
+++ b/frontend/src/lib/components/Sidebar.svelte
@@ -15,6 +15,9 @@
       <Item href="/">
         <Text>Home</Text>
       </Item>
+      <Item href="/admin/employees">
+        <Text>Employees</Text>
+      </Item>
       <Item href="/auth/login">
         <Text>Login</Text>
       </Item>

--- a/frontend/src/lib/components/admin/EmployeeList.svelte
+++ b/frontend/src/lib/components/admin/EmployeeList.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import DataTable, { Head, Body, Row, Cell } from '@smui/data-table';
+  import employeeStore from '$lib/stores/employeeStore';
+
+  onMount(() => {
+    employeeStore.fetchAll();
+  });
+</script>
+
+<h1>Employees</h1>
+
+{#if $employeeStore.loading}
+  <p>Loading...</p>
+{:else if $employeeStore.error}
+  <p style="color: red;">Error: {$employeeStore.error}</p>
+{:else}
+  <DataTable>
+    <Head>
+      <Row>
+        <Cell>ID</Cell>
+        <Cell>Name</Cell>
+        <Cell>Email</Cell>
+        <Cell>Position</Cell>
+      </Row>
+    </Head>
+    <Body>
+      {#each $employeeStore.employees as employee (employee.id)}
+        <Row>
+          <Cell>{employee.id}</Cell>
+          <Cell>{employee.first_name} {employee.last_name}</Cell>
+          <Cell>{employee.email}</Cell>
+          <Cell>{employee.position}</Cell>
+        </Row>
+      {/each}
+    </Body>
+  </DataTable>
+{/if}

--- a/frontend/src/lib/stores/employeeStore.ts
+++ b/frontend/src/lib/stores/employeeStore.ts
@@ -1,0 +1,33 @@
+import { writable } from 'svelte/store';
+import { apiFetch } from '$lib/utils/api';
+
+// Define the shape of the store's state
+interface EmployeeStore {
+  employees: any[]; // Replace 'any' with a proper Employee type later
+  loading: boolean;
+  error: string | null;
+}
+
+// Create the writable store with an initial state
+const { subscribe, set, update } = writable<EmployeeStore>({
+  employees: [],
+  loading: false,
+  error: null,
+});
+
+// Function to fetch all employees
+async function fetchAll() {
+  update(state => ({ ...state, loading: true, error: null }));
+  try {
+    const employees = await apiFetch('/employees');
+    update(state => ({ ...state, employees: employees, loading: false }));
+  } catch (e: any) {
+    update(state => ({ ...state, error: e.message, loading: false }));
+  }
+}
+
+// Expose the store's methods
+export default {
+  subscribe,
+  fetchAll,
+};

--- a/frontend/src/routes/admin/employees/+page.svelte
+++ b/frontend/src/routes/admin/employees/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import EmployeeList from '$lib/components/admin/EmployeeList.svelte';
+</script>
+
+<EmployeeList />


### PR DESCRIPTION
This commit introduces the first feature of the Admin Dashboard: the Employee List page.

Key Features:
- A new Svelte store (`employeeStore.ts`) to manage fetching and storing employee data from the backend.
- A new route at `/admin/employees` to display the employee list.
- A new `EmployeeList.svelte` component that uses an SMUI Data Table to render the list of employees.
- The main sidebar navigation has been updated to include a link to the new page.

Note: I was unable to run the tests successfully due to a persistent environment instability that prevented me from configuring and running the test runner correctly. As you directed, I've proceeded with the UI implementation regardless of these issues.