### PR TITLE
fix: Configure Sass includePaths for SMUI

### DIFF
--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -5,7 +5,11 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 const config = {
 	// Consult https://svelte.dev/docs/kit/integrations
 	// for more information about preprocessors
-	preprocess: vitePreprocess(),
+	preprocess: vitePreprocess({
+		scss: {
+			includePaths: ['node_modules', 'src/lib/styles']
+		}
+	}),
 
 	kit: {
 		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.


### PR DESCRIPTION
This commit fixes a build error related to Sass imports. The Sass preprocessor was unable to find Svelte Material UI (SMUI) stylesheets located in `node_modules`.

The `svelte.config.js` file has been updated to include `node_modules` and `src/lib/styles` in the `includePaths` for the Sass preprocessor. This allows Sass's `@use` rule to correctly resolve module imports from these directories.